### PR TITLE
1 use localstorage to cache request to pocketbase so views load faster

### DIFF
--- a/app/maze/page.tsx
+++ b/app/maze/page.tsx
@@ -5,6 +5,12 @@ import { login, getMazes, getRecalls } from "../db";
 import SideBar from "@/components/sidebar";
 import Maze from "../../components/maze";
 import { RecordModel } from "pocketbase";
+import {
+  setLocalRecalls,
+  getLocalRecalls,
+  setLocalMazes,
+  getLocalMazes,
+} from "../pbLocalStorage";
 
 export default function MazePage() {
   const [mazes, setMazes] = useState(Array<RecordModel>);
@@ -13,12 +19,30 @@ export default function MazePage() {
     var pb = login();
     const promMazes = async () => {
       console.log("DEBUG MazePage promMazes");
-      setMazes(await getMazes(pb));
+      const awaitedMazes = await getMazes(pb);
+      setMazes(awaitedMazes);
+      setLocalMazes(awaitedMazes);
+      console.log("DEBUG MazePage useEffect awaitedMazes: ", awaitedMazes);
     };
     const promRecalls = async () => {
       console.log("DEBUG MazePage promRecalls");
-      setRecalls(await getRecalls(pb));
+      const awaitedRecalls = await getRecalls(pb);
+      setRecalls(awaitedRecalls);
+      setLocalRecalls(awaitedRecalls);
+      console.log("DEBUG MazePage useEffect awaitedRecalls: ", awaitedRecalls);
     };
+    const localRecalls = getLocalRecalls();
+    setRecalls(localRecalls);
+    console.log(
+      "DEBUG MazePage useEffect: setting recalls from local ",
+      localRecalls
+    );
+    const localMazes = getLocalMazes();
+    setMazes(localMazes);
+    console.log(
+      "DEBUG MazePage useEffect: setting mazes from local ",
+      localMazes
+    );
     promMazes();
     promRecalls();
   }, []);

--- a/app/pbLocalStorage.ts
+++ b/app/pbLocalStorage.ts
@@ -1,0 +1,39 @@
+import { RecordModel } from "pocketbase";
+
+export function setLocalRecalls(recalls: Array<RecordModel>) {
+    if (typeof window === "undefined") {
+      console.log("DEBUG setLocalRecalls window: undefined");
+      return;
+    }
+    const recallsStringify = JSON.stringify(recalls);
+    window.localStorage.setItem("recalls", recallsStringify);
+  }
+  
+export function getLocalRecalls(): Array<RecordModel> {
+    if (typeof window === "undefined") {
+        console.log("DEBUG getLocalRecalls window: undefined");
+        return [];
+    }
+    var lovalValue = window.localStorage.getItem("recalls") || "[]";
+    var localRecalls: Array<RecordModel> = JSON.parse(lovalValue);
+    return localRecalls;
+}
+
+export function setLocalMazes(mazes: Array<RecordModel>) {
+    if (typeof window === "undefined") {
+      console.log("DEBUG setLocalMazes window: undefined");
+      return;
+    }
+    const mazesStringify = JSON.stringify(mazes);
+    window.localStorage.setItem("mazes", mazesStringify);
+  }
+  
+export function getLocalMazes(): Array<RecordModel> {
+    if (typeof window === "undefined") {
+        console.log("DEBUG getLocalMazes window: undefined");
+        return [];
+    }
+    var lovalValue = window.localStorage.getItem("mazes") || "[]";
+    var localMazes: Array<RecordModel> = JSON.parse(lovalValue);
+    return localMazes;
+}

--- a/app/pbLocalStorage.ts
+++ b/app/pbLocalStorage.ts
@@ -1,14 +1,22 @@
 import { RecordModel } from "pocketbase";
 
-export function setLocalRecalls(recalls: Array<RecordModel>) {
+function setLocal(modelName: string, arrayData: Array<any>) {
     if (typeof window === "undefined") {
-      console.log("DEBUG setLocalRecalls window: undefined");
-      return;
+        console.log("DEBUG setLocal window: undefined");
+        return;
     }
-    const recallsStringify = JSON.stringify(recalls);
-    window.localStorage.setItem("recalls", recallsStringify);
-  }
-  
+    const dataStringify = JSON.stringify(arrayData);
+    window.localStorage.setItem(modelName, dataStringify);
+}
+
+export function setLocalRecalls(recalls: Array<RecordModel>) {
+    setLocal("recalls", recalls);
+}
+
+export function setLocalMazes(mazes: Array<RecordModel>) {
+    setLocal("mazes", mazes);
+}
+
 export function getLocalRecalls(): Array<RecordModel> {
     if (typeof window === "undefined") {
         console.log("DEBUG getLocalRecalls window: undefined");
@@ -19,15 +27,6 @@ export function getLocalRecalls(): Array<RecordModel> {
     return localRecalls;
 }
 
-export function setLocalMazes(mazes: Array<RecordModel>) {
-    if (typeof window === "undefined") {
-      console.log("DEBUG setLocalMazes window: undefined");
-      return;
-    }
-    const mazesStringify = JSON.stringify(mazes);
-    window.localStorage.setItem("mazes", mazesStringify);
-  }
-  
 export function getLocalMazes(): Array<RecordModel> {
     if (typeof window === "undefined") {
         console.log("DEBUG getLocalMazes window: undefined");

--- a/app/pbLocalStorage.ts
+++ b/app/pbLocalStorage.ts
@@ -1,5 +1,10 @@
 import { RecordModel } from "pocketbase";
 
+const models = {
+    recalls: "recalls",
+    mazes: "mazes",
+}
+
 function setLocal(modelName: string, arrayData: Array<any>) {
     if (typeof window === "undefined") {
         console.log("DEBUG setLocal window: undefined");
@@ -9,30 +14,28 @@ function setLocal(modelName: string, arrayData: Array<any>) {
     window.localStorage.setItem(modelName, dataStringify);
 }
 
+function getLocal(modelName: string): Array<RecordModel> {
+    if (typeof window === "undefined") {
+        console.log("DEBUG getLocal window: undefined");
+        return [];
+    }
+    var lovalString = window.localStorage.getItem(modelName) || "[]";
+    var LocalValue: Array<RecordModel> = JSON.parse(lovalString);
+    return LocalValue;
+}
+
 export function setLocalRecalls(recalls: Array<RecordModel>) {
-    setLocal("recalls", recalls);
+    setLocal(models.recalls, recalls);
 }
 
 export function setLocalMazes(mazes: Array<RecordModel>) {
-    setLocal("mazes", mazes);
+    setLocal(models.mazes, mazes);
 }
 
 export function getLocalRecalls(): Array<RecordModel> {
-    if (typeof window === "undefined") {
-        console.log("DEBUG getLocalRecalls window: undefined");
-        return [];
-    }
-    var lovalValue = window.localStorage.getItem("recalls") || "[]";
-    var localRecalls: Array<RecordModel> = JSON.parse(lovalValue);
-    return localRecalls;
+    return getLocal(models.recalls);
 }
 
 export function getLocalMazes(): Array<RecordModel> {
-    if (typeof window === "undefined") {
-        console.log("DEBUG getLocalMazes window: undefined");
-        return [];
-    }
-    var lovalValue = window.localStorage.getItem("mazes") || "[]";
-    var localMazes: Array<RecordModel> = JSON.parse(lovalValue);
-    return localMazes;
+    return getLocal(models.mazes);
 }

--- a/app/pbLocalStorage.ts
+++ b/app/pbLocalStorage.ts
@@ -1,6 +1,10 @@
 import { RecordModel } from "pocketbase";
 
-const models = {
+type StringMap = {
+    [key: string]: string
+}
+
+const models: StringMap = {
     recalls: "recalls",
     mazes: "mazes",
 }


### PR DESCRIPTION
• Implemented local storage functionality for mazes and recalls data
• Added new file pbLocalStorage.ts with utility functions for managing local storage
• Created StringMap type for key-value pairs
• Implemented setLocal and getLocal functions for generic local storage operations
• Added specific functions for setting and getting mazes and recalls from local storage
• Updated MazePage component to use local storage for initial data loading and caching
• Improved error handling for cases where window object is undefined
• Enhanced debugging with additional console logs for tracking data flow
• Refactored useEffect hook in MazePage to handle both API calls and local storage operations