### PR TITLE
3 use localstorage to cache flashcards

### DIFF
--- a/app/pbLocalStorage.ts
+++ b/app/pbLocalStorage.ts
@@ -49,6 +49,10 @@ export function getLocalMazes(): Array<RecordModel> {
     return getLocal(models.mazes);
 }
 
+export function getLocalMaze(mazeId: string): Array<RecordModel> {
+    return getLocal(models.mazes).filter((maze) => maze.id === mazeId);
+}
+
 export function getLocalFlashcards(): Array<RecordModel> {
     return getLocal(models.flashcards);
 }

--- a/app/pbLocalStorage.ts
+++ b/app/pbLocalStorage.ts
@@ -7,6 +7,7 @@ type StringMap = {
 const models: StringMap = {
     recalls: "recalls",
     mazes: "mazes",
+    flashcards: "flashcards",
 }
 
 function setLocal(modelName: string, arrayData: Array<any>) {
@@ -36,10 +37,18 @@ export function setLocalMazes(mazes: Array<RecordModel>) {
     setLocal(models.mazes, mazes);
 }
 
+export function setLocalFlashcards(flashcards: Array<RecordModel>) {
+    setLocal(models.flashcards, flashcards);
+}
+
 export function getLocalRecalls(): Array<RecordModel> {
     return getLocal(models.recalls);
 }
 
 export function getLocalMazes(): Array<RecordModel> {
     return getLocal(models.mazes);
+}
+
+export function getLocalFlashcards(): Array<RecordModel> {
+    return getLocal(models.flashcards);
 }


### PR DESCRIPTION
• Added new functions getLocalFlashcards and getLocalMaze to retrieve data from localStorage
• Implemented functionality to store flashcards in localStorage using setLocalFlashcards
• Updated MazeID component to use local storage for initial flashcards and maze data
• Modified state type for flashcards to use the Flashcard type
• Added error handling for localStorage operations
• Refactored code to improve type safety and readability
• Updated useEffect hook to fetch and store data more efficiently
• Added new model "flashcards" to the pbLocalStorage module
• Implemented filtering function getLocalMaze to retrieve specific maze data